### PR TITLE
Add PrelimOptions in option.py

### DIFF
--- a/matilda/data/option.py
+++ b/matilda/data/option.py
@@ -32,6 +32,18 @@ class PerformanceOptions:
 
 
 @dataclass
+class PrelimOptions:
+    """Options for running PRELIM."""
+
+    max_perf: bool
+    abs_perf: bool
+    epsilon: float
+    beta_threshold: float
+    bound: bool
+    norm: bool
+
+
+@dataclass
 class AutoOptions:
     """Options for automatic processing steps in the model pipeline."""
 
@@ -138,7 +150,6 @@ class Options:
     pythia: PythiaOptions
     trace: TraceOptions
     outputs: OutputOptions
-
 
     @staticmethod
     def from_file(filepath: str) -> Options:

--- a/matilda/data/option.py
+++ b/matilda/data/option.py
@@ -140,6 +140,7 @@ class Options:
 
     parallel: ParallelOptions
     perf: PerformanceOptions
+    prelim: PrelimOptions
     auto: AutoOptions
     bound: BoundOptions
     norm: NormOptions

--- a/matilda/data/option.py
+++ b/matilda/data/option.py
@@ -140,7 +140,6 @@ class Options:
 
     parallel: ParallelOptions
     perf: PerformanceOptions
-    prelim: PrelimOptions
     auto: AutoOptions
     bound: BoundOptions
     norm: NormOptions


### PR DESCRIPTION
Before calling PRELIM, there is an opts.prelim should be created and passed to prelim as an argument. I need to define this datatype in option.py.